### PR TITLE
ci: 🎡 fix up to check if release has been created on all steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,9 +39,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
+        if: ${{ steps.release.outputs.release_created }}
         run: | # Install and link dependencies
           npm ci
       - name: Build
+        if: ${{ steps.release.outputs.release_created }}
         run: |
           npm run build
       - name: Publish to npm


### PR DESCRIPTION
Feilet i Github Actions pga. noen av stegene kjørte uten at "release" ble laget. 